### PR TITLE
Added options for SQLite tracer and to lowercase the column names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Use the `mbox` command to import a `.mbox` file into a SQLite database:
 
     mbox-to-sqlite mbox emails.db path/to/messages.mbox
 
+Add the --tracer option to print the SQLite internal SQL statements as they're being executed.
+
+    mbox-to-sqlite mbox --tracer emails.db path/to/messages.mbox
+
 You can try this out against an example containing a sample of 3,266 emails from the [Enron corpus](https://en.wikipedia.org/wiki/Enron_Corpus) like this:
 
     curl -O https://raw.githubusercontent.com/ivanhb/EMA/master/server/data/mbox/enron/mbox-enron-white-s-all.mbox

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Add the --tracer option to print the SQLite internal SQL statements as they're b
 
     mbox-to-sqlite mbox --tracer emails.db path/to/messages.mbox
 
+Add the --lowercol option to force the column names to be lower case.
+
+    mbox-to-sqlite mbox --lowercol emails.db path/to/messages.mbox
+
 You can try this out against an example containing a sample of 3,266 emails from the [Enron corpus](https://en.wikipedia.org/wiki/Enron_Corpus) like this:
 
     curl -O https://raw.githubusercontent.com/ivanhb/EMA/master/server/data/mbox/enron/mbox-enron-white-s-all.mbox

--- a/mbox_to_sqlite/cli.py
+++ b/mbox_to_sqlite/cli.py
@@ -28,7 +28,6 @@ def cli():
 
 def mbox(db_path, mbox_path, table, tracer, lowercol):
     "Import messages from an mbox file"
-    print('hello')
     if tracer:
         db = sqlite_utils.Database(db_path, tracer=sql_tracer)
     else:

--- a/mbox_to_sqlite/cli.py
+++ b/mbox_to_sqlite/cli.py
@@ -24,22 +24,32 @@ def cli():
 )
 @click.option("--table", default="messages")
 @click.option("--tracer", is_flag=True)
+@click.option("--lowercol", is_flag=True)
 
-def mbox(db_path, mbox_path, table, tracer):
+def mbox(db_path, mbox_path, table, tracer, lowercol):
     "Import messages from an mbox file"
+    print('hello')
     if tracer:
         db = sqlite_utils.Database(db_path, tracer=sql_tracer)
     else:
         db = sqlite_utils.Database(db_path)
     mbox = mailbox.mbox(mbox_path)
 
+    if lowercol:
+        message_id = "message-id"
+    else:
+        message_id = "Message-ID"
+
     def to_insert():
         for message in mbox.values():
-            row = dict(message.items())
+            if lowercol:
+                row = dict([(l.lower(), r) for l,r in message.items()])
+            else:
+                row = dict(message.items())
             row["payload"] = message.get_payload()
             yield row
 
-    db[table].upsert_all(to_insert(), alter=True, pk="Message-ID")
+    db[table].upsert_all(to_insert(), alter=True, pk=message_id)
 
     if not db[table].detect_fts():
         db[table].enable_fts(["payload", "subject"], create_triggers=True)


### PR DESCRIPTION
The --tracer option will now print out the SQL commands that the SQLite engine executes. This is helpful in trying to determine why some .mbox file cannot be loaded. For example, Google's Takeout produces .mbox files with email message header fields of mixed cases.

The --lowercol option will force the table column names to be lowercase.